### PR TITLE
[ci skip] removing user @goanpeca

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,5 @@ In order to produce a uniquely identifiable distribution:
 Feedstock Maintainers
 =====================
 
-* [@goanpeca](https://github.com/goanpeca/)
 * [@jaimergp](https://github.com/jaimergp/)
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -71,5 +71,4 @@ about:
 
 extra:
   recipe-maintainers:
-    - goanpeca
     - jaimergp


### PR DESCRIPTION
Manually removing @goanpeca from the maintainers list because the conda-forge-admin bot has not processed the request.

Closes #2